### PR TITLE
 provide an onResult option, with a callback called after each result

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ function square(x) {
 
 const pool = new Pool(4);  // spawns 4 child processes to complete your jobs
 
-pool.map([1, 2, 3], square)
+pool.map([1, 2, 3], square, {onResult: result => { doSomethingWith(result); }})
   .then(result => console.log(result));
 
 // [1, 4, 9]

--- a/build/pool.js
+++ b/build/pool.js
@@ -149,6 +149,9 @@ module.exports = function () {
           }
 
           result[data.index] = jsonUtils.safeParse(data.result);
+          if (job.options && job.options.onResult) {
+            job.options.onResult(result[data.index], data.index);
+          }
           tasksRemaining -= 1;
           if (tasksRemaining <= 0) {
             worker.deregisterJob(job.id);

--- a/build/worker-wrapper.js
+++ b/build/worker-wrapper.js
@@ -97,7 +97,7 @@ module.exports = function () {
         return;
       } // TODO: should this be an error?
 
-      this.registeredJobs[jobId] = { callback: callback, fnOrModulePath: fnOrModulePath, timeout: timeout };
+      this.registeredJobs[jobId] = { callback: callback, fnOrModulePath: fnOrModulePath, timeout: timeout, options: options };
       var modulePath = typeof fnOrModulePath === 'string' ? fnOrModulePath : null;
       var fnStr = typeof fnOrModulePath === 'function' ? fnOrModulePath.toString() : null;
       this.process.send({

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -110,6 +110,9 @@ module.exports = class Pool {
         }
 
         result[data.index] = jsonUtils.safeParse(data.result)
+        if (job.options && job.options.onResult) {
+          job.options.onResult(result[data.index], data.index);
+        }
         tasksRemaining -= 1
         if (tasksRemaining <= 0) {
           worker.deregisterJob(job.id)

--- a/lib/worker-wrapper.js
+++ b/lib/worker-wrapper.js
@@ -76,7 +76,7 @@ module.exports = class WorkerWrapper {
 
     if (this.terminated) { return }  // TODO: should this be an error?
 
-    this.registeredJobs[jobId] = {callback, fnOrModulePath, timeout}
+    this.registeredJobs[jobId] = {callback, fnOrModulePath, timeout, options}
     const modulePath = typeof fnOrModulePath === 'string' ? fnOrModulePath : null
     const fnStr = typeof fnOrModulePath === 'function' ? fnOrModulePath.toString() : null
     this.process.send({

--- a/test/pool.spec.js
+++ b/test/pool.spec.js
@@ -229,6 +229,22 @@ describe('Pool', function () {
         })
     })
 
+    it('should call a callback function on each result', function ()  {
+      const pool = new Pool(2)
+      const callbacks = []
+      const onResult = (result, index) => {
+        callbacks.push([result, index])
+        callbacks.sort()
+      }
+      return pool.map([1, 2], x => x, {onResult})
+        .then(function (result) {
+          callbacks.should.eql([
+            [1, 0],
+            [2, 1]
+          ])
+        })
+    })
+
   })
 
   describe('#apply', function () {


### PR DESCRIPTION
This adds an onResult option, when you want to listen to the results as they come, and not all at once. Useful for streaming, and also for showing results while still receiving them.